### PR TITLE
default to zstd22 and 1M blocks 

### DIFF
--- a/src/appimagetool.c
+++ b/src/appimagetool.c
@@ -156,13 +156,16 @@ int sfs_mksquashfs(char *source, char *destination, int offset) {
             args[i++] = "16384";
         } else if (strcmp(sqfs_comp, "zstd") == 0) {
             /*
-             * > Build with default 128K block size
+             * > Build with default 1M block size since this appimagetool is only meant to be used with small appimages
+             * > 1M blocks add a significant delay to the startup time of the application, but this only matters for appimages
+             * > bigger than 100 MiB, AT WHICH POINT YOU BETTER USE THE DWARFS URUNTIME INSTEAD
+
              * > It used to be 1M but that actually causes much higher startup times.
              * > Some testing might be needed to see if there is some other value that actually improves performance.
              * -- https://github.com/AppImage/appimagetool/issues/64
              */
             args[i++] = "-b";
-            args[i++] = "128K";
+            args[i++] = "1M";
             args[i++] = "-Xcompression-level";
             args[i++] = "22";
         }

--- a/src/appimagetool.c
+++ b/src/appimagetool.c
@@ -163,6 +163,8 @@ int sfs_mksquashfs(char *source, char *destination, int offset) {
              */
             args[i++] = "-b";
             args[i++] = "128K";
+            args[i++] = "-Xcompression-level";
+            args[i++] = "22";
         }
 
         // check if ignore file exists and use it if possible


### PR DESCRIPTION
This appimagetool is only really useful for small appimages (less than 40 MiB), since for everything else the dwarfs uruntime performs better in every way. 

using 1M blocks adds a significant delay to the startup time of the application, however this only really matters for +100 MiB appimages where the delay is measured in seconds.

for appimages less than 50 MiB the extra delay is usually less than 300ms at most, so better switch to 1M in this case. 